### PR TITLE
Update Rocky Linux to 9.4

### DIFF
--- a/.github/workflows/ci-9.yml
+++ b/.github/workflows/ci-9.yml
@@ -15,7 +15,7 @@ jobs:
           sudo apt-get -y install qemu-utils
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build
         run: |

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ ROOTFS_FN="Rocky-${OS_MAJOR_VER}-GenericCloud-Base-${ROOTFS_VER}.${ARCH}.qcow2"
 ROOTFS_URL="https://dl.rockylinux.org/pub/rocky/${OS_FULL_VER}/images/${ARCH}/${ROOTFS_FN}"
 
 # Environment variables for Yuk7's wsldl
-LNCR_BLD="22020900"
+LNCR_BLD="23072600"
 LNCR_ZIP="icons.zip"
 LNCR_NAME="Rocky"
 LNCR_FN=${LNCR_NAME}.exe

--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 # Environment variables for the Rocky Linux cloud image
 ARCH="x86_64"
 OS_MAJOR_VER="9"
-OS_FULL_VER="9.3"
-ROOTFS_VER="9.3-20231113.0"
+OS_FULL_VER="9.4"
+ROOTFS_VER="9.4-20240509.0"
 ROOTFS_FN="Rocky-${OS_MAJOR_VER}-GenericCloud-Base-${ROOTFS_VER}.${ARCH}.qcow2"
 ROOTFS_URL="https://dl.rockylinux.org/pub/rocky/${OS_FULL_VER}/images/${ARCH}/${ROOTFS_FN}"
 

--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 # Environment variables for the Rocky Linux cloud image
 ARCH="x86_64"
 OS_MAJOR_VER="9"
-OS_FULL_VER="9.2"
-ROOTFS_VER="9.2-20230513.0"
+OS_FULL_VER="9.3"
+ROOTFS_VER="9.3-20231113.0"
 ROOTFS_FN="Rocky-${OS_MAJOR_VER}-GenericCloud-Base-${ROOTFS_VER}.${ARCH}.qcow2"
 ROOTFS_URL="https://dl.rockylinux.org/pub/rocky/${OS_FULL_VER}/images/${ARCH}/${ROOTFS_FN}"
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ ROOTFS_FN="Rocky-${OS_MAJOR_VER}-GenericCloud-Base-${ROOTFS_VER}.${ARCH}.qcow2"
 ROOTFS_URL="https://dl.rockylinux.org/pub/rocky/${OS_FULL_VER}/images/${ARCH}/${ROOTFS_FN}"
 
 # Environment variables for Yuk7's wsldl
-LNCR_BLD="23072600"
+LNCR_BLD="24050601"
 LNCR_ZIP="icons.zip"
 LNCR_NAME="Rocky"
 LNCR_FN=${LNCR_NAME}.exe


### PR DESCRIPTION
Commit messages are quite evident, but I'm not sure why `CI 9` costs 10m19s in my test and yours only costs 2m35s.